### PR TITLE
Optimisation de la mémoire

### DIFF
--- a/src/flows.py
+++ b/src/flows.py
@@ -21,15 +21,16 @@ for db in ["datalab", "decp"]:
 DATE_NOW = datetime.now().isoformat()[0:10]  # YYYY-MM-DD
 
 
-@flow(log_prints=True)
+@task(log_prints=True)
 def get_merge_clean():
     print("Récupération des données source...")
-    df: pl.DataFrame = get_merge_decp(DATE_NOW)
+    df: pl.LazyFrame = get_merge_decp(DATE_NOW)
+    df = df.collect()
     print(f"DECP officielles: nombre de lignes: {df.height}")
     save_to_sqlite(df, "datalab", "data.economie.2019.2022")
 
     print("Nettoyage des données source...")
-    df = clean_decp(df)
+    df = clean_decp(df.lazy())
 
     print("Typage des colonnes...")
     df = fix_data_types(df)
@@ -48,8 +49,10 @@ def make_datalab_data():
     # Initialisation
     initialization()
 
-    # Récupération des données
-    df: pl.DataFrame = get_merge_clean()
+    # Récupération, fusion et nettoyage des données
+    df: pl.LazyFrame = get_merge_clean()
+
+    df = df.collect()
 
     print("Enregistrement des DECP aux formats CSV, Parquet et SQLite...")
     save_to_files(df, "dist/decp")
@@ -64,7 +67,7 @@ def make_decpinfo_data():
     # adapté à decp.info (datasette)
 
     # Récupération des données
-    df: pl.DataFrame = get_merge_clean()
+    df: pl.LazyFrame = get_merge_clean()
 
     print("Concaténation et explosion des titulaires, un par ligne...")
     df = explode_titulaires(df)
@@ -95,7 +98,7 @@ def make_decpinfo_data():
     return df
 
 
-@flow(log_prints=True)
+@task(log_prints=True)
 def enrich_from_sirene(df):
     # DONNÉES SIRENE ACHETEURS
 

--- a/src/tasks/analyse.py
+++ b/src/tasks/analyse.py
@@ -4,7 +4,9 @@ from datetime import datetime
 from tasks.get import get_stats
 
 
-def list_data_issues(df: pl.DataFrame):
+def list_data_issues(df: pl.LazyFrame):
+    df = df.collect()
+
     # Dates impossibles
 
     date_columns = [

--- a/src/tasks/clean.py
+++ b/src/tasks/clean.py
@@ -19,9 +19,9 @@ def clean_decp(df: pl.DataFrame):
 
     # Suppression des lignes en doublon par UID (acheteur id + id)
     # Exemple : 20005584600014157140791205100
-    index_size_before = df.height
-    df = df.unique(subset=["uid"], maintain_order=False)
-    print("-- ", index_size_before - df.height, " doublons supprimés (uid)")
+    # index_size_before = df.height
+    # df = df.unique(subset=["uid"], maintain_order=False)
+    # print("-- ", index_size_before - df.height, " doublons supprimés (uid)")
 
     # Dates
     date_replacements = {

--- a/src/tasks/get.py
+++ b/src/tasks/get.py
@@ -33,7 +33,7 @@ def get_decp_csv(date_now: str, year: str):
     else:
         print(f"DECP d'aujourd'hui déjà téléchargées ({date_now})")
 
-    df: pl.DataFrame = pl.read_csv(
+    df: pl.LazyFrame = pl.scan_csv(
         decp_augmente_valides_file,
         low_memory=True,
         separator=";",
@@ -56,7 +56,8 @@ def get_decp_csv(date_now: str, year: str):
             "TypePrix"
         )  # SQlite le voit comme un doublon de typePrix, et les données semblent être les mêmes
 
-    save_to_sqlite(df, "datalab", f"data.economie.{year}.ori")
+    save_to_sqlite(df.collect(), "datalab", f"data.economie.{year}.ori")
+    df = df.lazy()
     df = df.with_columns(
         pl.lit(f"data.economie valides {year}").alias("source_open_data")
     )
@@ -104,13 +105,6 @@ def get_merge_decp(date_now: str):
     )
 
     # Concaténation des données format 2019 et 2022
-    for col in dfs["2019"].columns:
-        try:
-            if dfs["2019"][col].dtype != dfs["2022"][col].dtype:
-                print(col, ": ", dfs["2019"][col].dtype, dfs["2022"][col].dtype)
-        except ColumnNotFoundError:
-            print(f"Column {col} is not in 2022")
-
     df = pl.concat([dfs["2019"], dfs["2022"]], how="diagonal")
     del dfs
 

--- a/src/tasks/get.py
+++ b/src/tasks/get.py
@@ -35,6 +35,7 @@ def get_decp_csv(date_now: str, year: str):
 
     df: pl.DataFrame = pl.read_csv(
         decp_augmente_valides_file,
+        low_memory=True,
         separator=";",
         schema_overrides={
             "titulaire_id_1": str,
@@ -111,6 +112,7 @@ def get_merge_decp(date_now: str):
             print(f"Column {col} is not in 2022")
 
     df = pl.concat([dfs["2019"], dfs["2022"]], how="diagonal")
+    del dfs
 
     return df
 

--- a/src/tasks/get.py
+++ b/src/tasks/get.py
@@ -56,7 +56,8 @@ def get_decp_csv(date_now: str, year: str):
             "TypePrix"
         )  # SQlite le voit comme un doublon de typePrix, et les données semblent être les mêmes
 
-    save_to_sqlite(df.collect(), "datalab", f"data.economie.{year}.ori")
+    df = df.collect()
+    save_to_sqlite(df, "datalab", f"data.economie.{year}.ori")
     df = df.lazy()
     df = df.with_columns(
         pl.lit(f"data.economie valides {year}").alias("source_open_data")


### PR DESCRIPTION
`read_csv(low_memory=True)` et  `del dfs` après la concaténation des données format 2019 et 2022 n'ont pas eu de gros impact sur la conso mémoire.

Issue => #25 