### PR TITLE
Fix sur encoding et ajout du fichier env

### DIFF
--- a/src/flows.py
+++ b/src/flows.py
@@ -58,7 +58,7 @@ def make_datalab_data():
     save_to_files(df, "dist/decp")
     save_to_sqlite(df, "datalab", "data.gouv.fr.2022.clean")
 
-    if os.environ["DECP_PROCESSING_PUBLISH"]:
+    if os.getenv("DEBUG", 'False').lower() == 'true':
         print("Publication sur data.gouv.fr...")
         publish_to_datagouv()
 

--- a/src/tasks/get.py
+++ b/src/tasks/get.py
@@ -39,7 +39,7 @@ def get_decp_json(json_files: dict, date_now: str) -> list:
         if json_file["process"] is True:
             decp_json_file: Path = get_json(date_now, json_file)
 
-            with open(decp_json_file) as f:
+            with open(decp_json_file, encoding="utf8") as f:
                 decp_json = json.load(f)
 
             filename = json_file["file_name"]


### PR DESCRIPTION
J'avais des erreurs à faire tourner le code. Je ne sais pas si c'est spécifique à mon run ou si tu avais les mêmes erreurs en repartant d'un env vide. Du coup j'ai ajouté le fix qui l'utf8 qui me sortait une erreur et le fichier .env pour les variables d'environnement.