### PR TITLE
refactor path config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,28 +2,37 @@ import json
 import os
 import shutil
 from datetime import datetime
+from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
-if not os.path.exists(".env"):
+dotenv_path = find_dotenv()
+if dotenv_path == "":
     print("Création du fichier .env à partir de template.env")
-    shutil.copyfile("template.env", ".env")
+    template_dotenv_path = Path(find_dotenv("template.env"))
+    dotenv_path = template_dotenv_path.with_name(".env")
+    shutil.copyfile(template_dotenv_path, dotenv_path)
 
-# Les variables configurées sur le serveur doivent avoir la priorité
-load_dotenv(override=False)
+load_dotenv(dotenv_path, override=False)
 
 DATE_NOW = datetime.now().isoformat()[0:10]  # YYYY-MM-DD
 MONTH_NOW = DATE_NOW[2:10]
 
 DECP_PROCESSING_PUBLISH = os.environ.get("DECP_PROCESSING_PUBLISH", "")
 
-SIRENE_DATA_DIR = os.getenv("SIRENE_DATA_DIR", "./data/sirene")
-DIST_DIR = os.getenv("DECP_DIST_DIR", "./dist")
+BASE_DIR = Path(dotenv_path).parent
 
-if not os.path.exists(DIST_DIR):
-    os.mkdir(DIST_DIR)
+# Les variables configurées sur le serveur doivent avoir la priorité
+DATA_DIR = Path(os.getenv("DATA_DIR", BASE_DIR / "data"))
+DATA_DIR.mkdir(exist_ok=True)
 
-with open(os.getenv("DECP_JSON_FILES_PATH", "data/decp_json_files.json")) as f:
+DIST_DIR = Path(os.getenv("DECP_DIST_DIR", BASE_DIR / "dist"))
+DIST_DIR.mkdir(exist_ok=True)
+
+SIRENE_DATA_DIR = Path(os.getenv("SIRENE_DATA_DIR", DATA_DIR / "sirene"))
+SIRENE_DATA_DIR.mkdir(exist_ok=True)
+
+with open(os.getenv("DECP_JSON_FILES_PATH", DATA_DIR / "decp_json_files.json")) as f:
     DECP_JSON_FILES = json.load(f)
 
 # Liste et ordre des colonnes pour le mono dataframe de base (avant normalisation et spécialisation)

--- a/src/config.py
+++ b/src/config.py
@@ -20,7 +20,7 @@ MONTH_NOW = DATE_NOW[2:10]
 
 DECP_PROCESSING_PUBLISH = os.environ.get("DECP_PROCESSING_PUBLISH", "")
 
-BASE_DIR = Path(dotenv_path).parent
+BASE_DIR = Path(__file__).parent.parent
 
 # Les variables configurées sur le serveur doivent avoir la priorité
 DATA_DIR = Path(os.getenv("DATA_DIR", BASE_DIR / "data"))

--- a/src/tasks/clean.py
+++ b/src/tasks/clean.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import polars as pl
 from prefect import task
@@ -9,7 +9,7 @@ from tasks.transform import explode_titulaires
 
 
 @task
-def clean_decp_json(files: list):
+def clean_decp_json(files: list[Path]):
     return_files = []
     for file in files:
         #
@@ -79,13 +79,12 @@ def clean_decp_json(files: list):
         # Fix datatypes
         lf = fix_data_types(lf)
 
-        file = f"{DIST_DIR}/clean/{file.split('/')[-1]}"
-        return_files.append(file)
-        if not os.path.exists(f"{DIST_DIR}/clean"):
-            os.mkdir(f"{DIST_DIR}/clean")
+        output_file = DIST_DIR / "clean" / file.name
+        return_files.append(output_file)
+        output_file.parent.mkdir(exist_ok=True)
 
         df: pl.DataFrame = lf.collect()
-        save_to_files(df, file, ["parquet"])
+        save_to_files(df, output_file, ["parquet"])
 
     return return_files
 

--- a/src/tasks/enrich.py
+++ b/src/tasks/enrich.py
@@ -1,5 +1,3 @@
-from os import getenv
-
 import polars as pl
 
 from config import SIRENE_DATA_DIR
@@ -18,8 +16,9 @@ def add_etablissement_data(
         "codeCommuneEtablissement": "object",
         "etatAdministratifEtablissement": "category",
     }
+    # TODO: fix
     etablissement_df_chunked = pl.scan_csv(
-        getenv(f"{SIRENE_DATA_DIR}/etablissements.parquet"),
+        SIRENE_DATA_DIR / "etablissements.parquet",
         dtype=schema_etablissements,
         index_col=None,
         usecols=["siret"] + etablissement_columns,
@@ -42,7 +41,7 @@ def add_unite_legale_data(
     df_sirets = df_sirets.with_columns(pl.col(siret_column).str.head(9).alias("siren"))
 
     # Récupération des données des unités légales issues du flow de preprocess
-    unites_legales_lf = pl.scan_parquet(SIRENE_DATA_DIR + "/unites_legales.parquet")
+    unites_legales_lf = pl.scan_parquet(SIRENE_DATA_DIR / "unites_legales.parquet")
 
     # Pas besoin de garder les SIRET qui ne matchent pas dans ce df intermédiaire, puisqu'on
     # merge in fine avec le reste des données

--- a/src/tasks/output.py
+++ b/src/tasks/output.py
@@ -1,11 +1,12 @@
 import sqlite3
+from pathlib import Path
 
 import polars as pl
 
 from config import DIST_DIR
 
 
-def save_to_files(df: pl.DataFrame, path: str, file_format=None):
+def save_to_files(df: pl.DataFrame, path: str | Path, file_format=None):
     if file_format is None:
         file_format = ["csv", "parquet"]
     if "csv" in file_format:
@@ -36,7 +37,7 @@ def save_to_sqlite(df: pl.DataFrame, database: str, table_name: str, primary_key
     create_table_sql = f'CREATE TABLE "{table_name}" ({", ".join(column_definitions)}, {primary_key_definition})'  # Add quotes
 
     # Éxecution de la requête
-    connection = sqlite3.connect(f"{DIST_DIR}/{database}.sqlite")
+    connection = sqlite3.connect(DIST_DIR / f"{database}.sqlite")
     cursor = connection.cursor()
     # Important de "DROP TABLE IF EXISTS", le fichier sqlite de la veille pré-existera en général
     cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')
@@ -62,14 +63,14 @@ def make_data_package():
 
     outputs = [
         {
-            "csv": f"{DIST_DIR}/decp.csv",
+            "csv": str(DIST_DIR / "decp.csv"),
             "steps": common_steps
             + [
                 steps.field_update(name="titulaire_id", descriptor={"type": "string"}),
             ],
         },
         {
-            "csv": f"{DIST_DIR}/decp-sans-titulaires.csv",
+            "csv": str(DIST_DIR / "decp-sans-titulaires.csv"),
             "steps": common_steps,
         },
         # {
@@ -96,4 +97,4 @@ def make_data_package():
         description="Données essentielles de la commande publique (FR) au format tabulaire v2.",
         resources=resources,
         # it's possible to provide all the official properties like homepage, version, etc
-    ).to_json(f"{DIST_DIR}/datapackage.json")
+    ).to_json(DIST_DIR / "datapackage.json")

--- a/src/tasks/publish.py
+++ b/src/tasks/publish.py
@@ -20,46 +20,46 @@ def publish_to_datagouv(context: str):
     dataset_id = "608c055b35eb4e6ee20eb325"
 
     uploads = [
-        # {"file": f"{DIST_DIR}/decp.csv", "resource_id": "8587fe77-fb31-4155-8753-f6a3c5e0f5c9"},
+        # {"file": str(DIST_DIR/"decp.csv"), "resource_id": "8587fe77-fb31-4155-8753-f6a3c5e0f5c9"},
         {
-            "file": f"{DIST_DIR}/decp.parquet",
+            "file": str(DIST_DIR / "decp.parquet"),
             "resource_id": "11cea8e8-df3e-4ed1-932b-781e2635e432",
             "context": context,
         },
         # {
-        #     "file": f"{DIST_DIR}/decp-titulaires.csv",
+        #     "file": str(DIST_DIR/"decp-titulaires.csv"),
         #     "resource_id": "25fcd9e6-ce5a-41a7-b6c0-f140abb2a060",
         # },
         # {
-        #     "file": f"{DIST_DIR}/decp-titulaires.parquet",
+        #     "file": str(DIST_DIR/"decp-titulaires.parquet"),
         #     "resource_id": "ed8cbf31-2b86-4afc-9696-3c0d7eae5c64",
         # },
         {
-            "file": f"{DIST_DIR}/decp-sans-titulaires.csv",
+            "file": str(DIST_DIR / "decp-sans-titulaires.csv"),
             "resource_id": "834c14dd-037c-4825-958d-0a841c4777ae",
             "context": "decp",
         },
         {
-            "file": f"{DIST_DIR}/decp-sans-titulaires.parquet",
+            "file": str(DIST_DIR / "decp-sans-titulaires.parquet"),
             "resource_id": "df28fa7d-2d36-439b-943a-351bde02f01d",
             "context": "decp",
         },
         {
-            "file": f"{DIST_DIR}/datalab.sqlite",
+            "file": str(DIST_DIR / "datalab.sqlite"),
             "resource_id": "43f54982-da60-4eb7-aaaf-ba935396209b",
             "context": "datalab",
         },
         # {
-        #     "file": f"{DIST_DIR}/decp.sqlite",
+        #     "file": str(DIST_DIR/"decp.sqlite"),
         #     "resource_id": "c6b08d03-7aa4-4132-b5b2-fd76633feecc",
         #     "context": "decp",
         # },
         # {
-        #     "file": f"{DIST_DIR}/datapackage.json",
+        #     "file": str(DIST_DIR/"datapackage.json"),
         #     "resource_id": "65194f6f-e273-4067-8075-56f072d56baf",
         #     "context": "decp",
         # },
-        # {"file": f"{DIST_DIR}/statistiques.csv", "resource_id": "8ded94de-3b80-4840-a5bb-7faad1c9c234"},
+        # {"file": str(DIST_DIR/"statistiques.csv"), "resource_id": "8ded94de-3b80-4840-a5bb-7faad1c9c234"},
     ]
 
     for upload in uploads:

--- a/src/tasks/test.py
+++ b/src/tasks/test.py
@@ -1,10 +1,11 @@
 from tableschema import Table
+
 from config import DIST_DIR
 
 
 def validate_decp_against_tableschema():
     table = Table(
-        f"{DIST_DIR}/decp.csv",
+        str(DIST_DIR / "decp.csv"),
         schema="https://raw.githubusercontent.com/ColinMaudry/decp-table-schema/main/schema.json",
     )
 

--- a/src/tasks/transform.py
+++ b/src/tasks/transform.py
@@ -5,7 +5,7 @@ import polars as pl
 from httpx import get
 from prefect import task
 
-from config import SIRENE_DATA_DIR
+from config import DATA_DIR, SIRENE_DATA_DIR
 from tasks.output import save_to_sqlite
 
 
@@ -64,12 +64,10 @@ def explode_titulaires(df: pl.LazyFrame):
     return df
 
 
-def normalize_tables(df):
+def normalize_tables(df: pl.DataFrame):
     # MARCHES
 
-    df_marches: pl.DataFrame = pl.DataFrame(df.to_arrow()).drop(
-        "titulaire_id", "titulaire_typeIdentifiant"
-    )
+    df_marches: pl.DataFrame = df.drop("titulaire_id", "titulaire_typeIdentifiant")
     df_marches = df_marches.unique("uid").sort(
         by="datePublicationDonnees", descending=True
     )
@@ -185,29 +183,27 @@ def extract_unique_titulaires_siret(df: pl.LazyFrame):
 
 @task
 def get_prepare_unites_legales():
-    sirene_data_dir = SIRENE_DATA_DIR
-
-    unites_legales_path = f"{sirene_data_dir}/StockUniteLegale_utf8"
-    if not os.path.exists(f"{unites_legales_path}.zip"):
+    data_dir = SIRENE_DATA_DIR
+    zip_path = data_dir / "StockUniteLegale_utf8.zip"
+    if not zip_path.exists():
         print("Téléchargement des unités légales...")
-        unites_legales_url = os.getenv("SIRENE_UNITES_LEGALES_URL")
+        unites_legales_url = os.environ["SIRENE_UNITES_LEGALES_URL"]
 
         request = get(unites_legales_url, follow_redirects=True)
-        with open(f"{unites_legales_path}.zip", "wb") as file:
+        with open(zip_path, "wb") as file:
             file.write(request.content)
 
-    if not os.path.exists(f"{unites_legales_path}.csv"):
+    csv_path = zip_path.with_suffix(".csv")
+    if not csv_path.exists():
         print("Décompression des unités légales...")
-        with zipfile.ZipFile(f"{unites_legales_path}.zip", "r") as zip_ref:
-            zip_ref.extractall(sirene_data_dir)
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            zip_ref.extractall(data_dir)
 
     print("-- sélection des colonnes et enregistrement au format parquet...")
-    lf_ul = pl.scan_csv(f"{unites_legales_path}.csv", infer_schema=None)
+    lf_ul = pl.scan_csv(csv_path, infer_schema=None)
     lf_ul = lf_ul.select(["siren", "denominationUniteLegale"])
     lf_ul = lf_ul.sort(by="siren")
-    lf_ul.collect(engine="streaming").write_parquet(
-        f"{sirene_data_dir}/unites_legales.parquet"
-    )
+    lf_ul.collect(engine="streaming").write_parquet(data_dir / "unites_legales.parquet")
 
 
 def sort_columns(df: pl.DataFrame, config_columns):
@@ -278,7 +274,7 @@ def improve_categories_juridiques(df_sirets_titulaires: pl.DataFrame):
     )
 
     # Récupération des libellés des catégories juridiques
-    cj_df = pl.read_csv("data/cj.csv", index_col=None, dtype="object")
+    cj_df = pl.read_csv(DATA_DIR / "cj.csv", index_col=None, dtype="object")
     df_sirets_titulaires = pl.merge(
         df_sirets_titulaires,
         cj_df,


### PR DESCRIPTION
J'ai voulu faire quelques tests depuis un notebook placé à un endroit aléatoire, et comme ça m'a posé des problèmes de paths non alignés avec ce que le code library attend, je me suis dit que je pourrais commencer par faire un petit refactor sur ce plan là. La PR fait en sorte que tous les paths découlent d'un seul dossier `BASE_DIR`, à part s'ils sont configurés manuellement par l'environnement. J'en ai profité pour tout passé en `pathlib.Path`, qui est bien plus sympa à travailler avec.