### PR TITLE
Ne garder que le dernier SIREN s'il y en a plusieurs identiques

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ logs
 !decp_augmente_valides_*_test.csv
 .venv
 *.egg-info
-*.parquet
+*.parquetgit
 *.gz
 *.zip
 __pycache__
@@ -18,4 +18,7 @@ data/decp-*.json
 test.*
 wiki
 *.lock
-*.ndjson
+data/get
+data/clean
+data/sirene*
+system

--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,7 @@ if dotenv_path == "":
 load_dotenv(dotenv_path, override=False)
 
 DATE_NOW = datetime.now().isoformat()[0:10]  # YYYY-MM-DD
-MONTH_NOW = DATE_NOW[2:10]
+MONTH_NOW = DATE_NOW[:7]
 
 DECP_PROCESSING_PUBLISH = os.environ.get("DECP_PROCESSING_PUBLISH", "")
 
@@ -29,8 +29,8 @@ DATA_DIR.mkdir(exist_ok=True)
 DIST_DIR = Path(os.getenv("DECP_DIST_DIR", BASE_DIR / "dist"))
 DIST_DIR.mkdir(exist_ok=True)
 
-SIRENE_DATA_DIR = Path(os.getenv("SIRENE_DATA_DIR", DATA_DIR / "sirene"))
-SIRENE_DATA_DIR.mkdir(exist_ok=True)
+sirene_data_parent_dir = Path(os.getenv("SIRENE_DATA_PARENT_DIR", DATA_DIR))
+SIRENE_DATA_DIR = sirene_data_parent_dir / f"sirene_{MONTH_NOW}"
 
 with open(os.getenv("DECP_JSON_FILES_PATH", DATA_DIR / "decp_json_files.json")) as f:
     DECP_JSON_FILES = json.load(f)

--- a/src/flows.py
+++ b/src/flows.py
@@ -3,8 +3,15 @@ import shutil
 
 import polars as pl
 from prefect import flow, task
+from prefect.transactions import transaction
 
-from config import BASE_DF_COLUMNS, DECP_PROCESSING_PUBLISH, DIST_DIR
+from config import (
+    BASE_DF_COLUMNS,
+    DATE_NOW,
+    DECP_PROCESSING_PUBLISH,
+    DIST_DIR,
+    SIRENE_DATA_DIR,
+)
 from tasks.analyse import generate_stats
 from tasks.clean import clean_decp
 from tasks.enrich import add_unite_legale_data
@@ -14,6 +21,7 @@ from tasks.output import (
     save_to_sqlite,
 )
 from tasks.publish import publish_to_datagouv
+from tasks.setup import create_sirene_data_dir
 from tasks.transform import (
     concat_decp_json,
     extract_unique_acheteurs_siret,
@@ -57,6 +65,8 @@ def make_datalab_data():
     """Tâches consacrées à la transformation des données dans un format
     adapté aux activités du Datalab d'Anticor."""
 
+    print("🚀  Création des données pour le Datalab d'Anticor...")
+
     df: pl.DataFrame = pl.read_parquet(DIST_DIR / "decp.parquet")
 
     print("Enregistrement des DECP aux formats SQLite...")
@@ -76,11 +86,15 @@ def make_datalab_data():
     else:
         print("Publication sur data.gouv.fr désactivée.")
 
+    print("☑️  Fin du flow make_datalab_data.")
+
 
 @flow(log_prints=True)
 def make_decpinfo_data():
     """Tâches consacrées à la transformation des données dans un format
     # adapté à decp.info"""
+
+    print("🚀  Création des données pour decp.info...")
 
     df: pl.DataFrame = pl.read_parquet(DIST_DIR / "decp.parquet")
 
@@ -106,11 +120,15 @@ def make_decpinfo_data():
     else:
         print("Publication sur data.gouv.fr désactivée.")
 
+    print("☑️  Fin du flow make_decpinfo_data.")
+
     return df
 
 
 @flow(log_prints=True)
 def decp_processing():
+    print("🚀  Début du flow principal")
+
     # Données nettoyées et fusionnées
     get_clean_concat()
 
@@ -120,10 +138,16 @@ def decp_processing():
     # Base de données SQLite dédiée aux activités du Datalab d'Anticor
     make_datalab_data()
 
+    print("☑️  Fin du flow principal decp_processing.")
+
 
 @task(log_prints=True)
 def enrich_from_sirene(df: pl.LazyFrame):
-    sirene_preprocess()
+    # Préprocessing des données SIRENE si :
+    # - le dossier n'existe pas encore (= les données n'ont pas déjà été preprocessed ce mois-ci)
+    # - on est au moins le 5 du mois (pour être sûr que les données SIRENE ont été mises à jour sur data.gouv.fr)
+    if not SIRENE_DATA_DIR.exists() and int(DATE_NOW[-2:]) >= 5:
+        sirene_preprocess()
 
     # DONNÉES SIRENE ACHETEURS
 
@@ -188,11 +212,21 @@ def sirene_preprocess():
     """Prétraitement mensuel des données SIRENE afin d'économiser du temps lors du traitement quotidien des DECP.
     Pour chaque ressource (unités légales, établissements), un fichier parquet est produit.
     """
-    # préparer lest données établissements
 
-    # préparer les données unités légales
-    print("Prépararion des unités légales...")
-    get_prepare_unites_legales()
+    print("🚀  Pré-traitement des données SIRENE")
+    # Soit les tâches de ce flow vont au bout (success), soit le dossier SIRENE_DATA_DIR est supprimé (voir remove_sirene_data_dir())
+    with transaction():
+        create_sirene_data_dir()
+
+        # TODO préparer lest données établissements
+
+        # préparer les données unités légales
+        processed_parquet_path = SIRENE_DATA_DIR / "unites_legales.parquet"
+        if not processed_parquet_path.exists():
+            print("Prépararion des unités légales...")
+            get_prepare_unites_legales(processed_parquet_path)
+
+    print("☑️  Fin du flow sirene_preprocess.")
 
 
 if __name__ == "__main__":

--- a/src/flows.py
+++ b/src/flows.py
@@ -123,6 +123,8 @@ def decp_processing():
 
 @task(log_prints=True)
 def enrich_from_sirene(df: pl.LazyFrame):
+    sirene_preprocess()
+
     # DONNÉES SIRENE ACHETEURS
 
     print("Extraction des SIRET des acheteurs...")

--- a/src/tasks/clean.py
+++ b/src/tasks/clean.py
@@ -8,7 +8,7 @@ import polars as pl
 import polars.selectors as cs
 from prefect import task
 
-from config import DIST_DIR
+from config import DATA_DIR
 from tasks.output import save_to_files
 from tasks.transform import explode_titulaires, process_modifications
 
@@ -84,7 +84,7 @@ def clean_decp(files: list[Path]):
         # Fix datatypes
         lf = fix_data_types(lf)
 
-        output_file = DIST_DIR / "clean" / file.name
+        output_file = DATA_DIR / "clean" / file.name
         return_files.append(output_file)
         output_file.parent.mkdir(exist_ok=True)
 

--- a/src/tasks/get.py
+++ b/src/tasks/get.py
@@ -8,7 +8,7 @@ from httpx import get
 from polars.polars import ColumnNotFoundError
 from prefect import task
 
-from config import DATA_DIR, DATE_NOW, DECP_JSON_FILES, DIST_DIR
+from config import DATA_DIR, DATE_NOW, DECP_JSON_FILES
 from schemas import MARCHE_SCHEMA_2022
 from tasks.clean import load_and_fix_json
 from tasks.output import save_to_files
@@ -22,7 +22,8 @@ def get_json(date_now, json_file: dict):
 
     if url.startswith("https"):
         # Prod file
-        decp_json_file: Path = DATA_DIR / f"{filename}_{date_now}.json"
+        decp_json_file: Path = DATA_DIR / "get" / f"{filename}_{date_now}.json"
+        decp_json_file.parent.mkdir(exist_ok=True)
         if not (os.path.exists(decp_json_file)):
             request = get(url, follow_redirects=True)
             with open(decp_json_file, "wb") as file:
@@ -130,8 +131,7 @@ def get_decp_json() -> list[Path]:
 
             print(f"[{filename}]", df.shape)
 
-            file_path = DIST_DIR / "get" / f"{filename}_{date_now}"
-            file_path.parent.mkdir(exist_ok=True)
+            file_path = DATA_DIR / "get" / f"{filename}_{date_now}"
             save_to_files(df, file_path, ["parquet"])
 
             return_files.append(file_path)

--- a/src/tasks/setup.py
+++ b/src/tasks/setup.py
@@ -1,5 +1,10 @@
+import os
+import shutil
+
 from prefect import task
 from prefect.artifacts import create_table_artifact
+
+from config import SIRENE_DATA_DIR
 
 
 @task()
@@ -18,3 +23,16 @@ def create_artifact(
 ):
     if data is list:
         create_table_artifact(key=key, table=data, description=description)
+
+
+@task
+def create_sirene_data_dir():
+    os.makedirs(SIRENE_DATA_DIR, exist_ok=True)
+
+
+# Si une tâche postérieure échoue dans le même flow que create_sirene_data_dir(), le dossier est supprimé
+# Ainsi on garantie que si le dossier est présent, c'est que le flow (sirene_preprocess) est allé au bout
+# https://docs.prefect.io/v3/advanced/transactions
+@create_sirene_data_dir.on_rollback
+def remove_sirene_data_dir(transaction):
+    shutil.rmtree(SIRENE_DATA_DIR)

--- a/template.env
+++ b/template.env
@@ -11,8 +11,8 @@ DECP_PROCESSING_PUBLISH=False
 # La clé API se trouve dans votre compte data.gouv.fr
 DATAGOUVFR_API_KEY=
 
-# Le dossier où seront stockées les données SIRENE téléchargées
-SIRENE_DATA_DIR=./data/sirene
+# Le dossier où seront stockées les données SIRENE téléchargées (un dossier par mois)
+SIRENE_DATA_PARENT_DIR=./data
 
 # L'URL à laquelle télécharger le parquet des unités légales (Historique)
 SIRENE_UNITES_LEGALES_URL=https://www.data.gouv.fr/fr/datasets/r/1b9290ed-d0bc-461f-ba31-0250a99cc140

--- a/template.env
+++ b/template.env
@@ -12,7 +12,7 @@ DECP_PROCESSING_PUBLISH=False
 DATAGOUVFR_API_KEY=
 
 # Le dossier où seront stockées les données SIRENE téléchargées
-SIRENE_DATA_DIR=/chemin/vers/données/sirene
+SIRENE_DATA_DIR=./data/sirene
 
 # L'URL à laquelle télécharger le zip des unités légales (pas Historique)
 SIRENE_UNITES_LEGALES_URL=https://www.data.gouv.fr/fr/datasets/r/0835cd60-2c2a-497b-bc64-404de704ce89

--- a/template.env
+++ b/template.env
@@ -14,8 +14,8 @@ DATAGOUVFR_API_KEY=
 # Le dossier où seront stockées les données SIRENE téléchargées
 SIRENE_DATA_DIR=./data/sirene
 
-# L'URL à laquelle télécharger le zip des unités légales (pas Historique)
-SIRENE_UNITES_LEGALES_URL=https://www.data.gouv.fr/fr/datasets/r/0835cd60-2c2a-497b-bc64-404de704ce89
+# L'URL à laquelle télécharger le parquet des unités légales (Historique)
+SIRENE_UNITES_LEGALES_URL=https://www.data.gouv.fr/fr/datasets/r/1b9290ed-d0bc-461f-ba31-0250a99cc140
 
 # L'adresse de l'API Prefect de production
 # (pour les tests un serveur temporaire est créé en local)


### PR DESCRIPTION
- Dans la base Unités légales historique, dédupliquer les sirenes en ne gardant que la ligne la plus récente
- Faire que le téléchargement du fichier sirene se fasse en lançant le src/flow.py pour que celà fonctionne directement avec un nouvel environnement